### PR TITLE
Fix out of bound error

### DIFF
--- a/projects/tailwind-ast/src/ast/parse.rs
+++ b/projects/tailwind-ast/src/ast/parse.rs
@@ -183,8 +183,9 @@ fn take_until_unbalanced(
                     // Skip the escape char `\`.
                     index += '\\'.len_utf8();
                     // Skip also the following char.
-                    let c = it.next().unwrap_or_default();
-                    index += c.len_utf8();
+                    if let Some(c) = it.next() {
+                        index += c.len_utf8();
+                    }
                 }
                 c if c == opening_bracket => {
                     bracket_counter += 1;


### PR DESCRIPTION
This PR fixes an out of bound error I found while fuzzing.  The bug seems to occur in a piece of code that came from https://gitlab.com/getreu/parse-hyperlinks/-/blob/master/parse-hyperlinks/src/lib.rs  where I also opened a PR with the same fix.

# Minimal reproduction

```rust
use tailwind_css::TailwindBuilder;

fn main() {
    let mut tailwind = TailwindBuilder::default();
    let _ = tailwind.inline("(\\");
}
```
