### PR TITLE
🔧 Fix builtin `FontSize` line heights

### DIFF
--- a/projects/tailwind-to-css/src/systems/font_system/builtin.rs
+++ b/projects/tailwind-to-css/src/systems/font_system/builtin.rs
@@ -19,11 +19,11 @@ impl FontSystem {
         self.insert_size("2xl", FontSize::new(1.5, 2.0));
         self.insert_size("3xl", FontSize::new(1.875, 2.25));
         self.insert_size("4xl", FontSize::new(2.25, 2.5));
-        self.insert_size("5xl", FontSize::new(3.0, -1.0));
-        self.insert_size("6xl", FontSize::new(3.75, -1.0));
-        self.insert_size("7xl", FontSize::new(4.5, -1.0));
-        self.insert_size("8xl", FontSize::new(6.0, -1.0));
-        self.insert_size("9xl", FontSize::new(8.0, -1.0));
+        self.insert_size("5xl", FontSize::new(3.0, -100.));
+        self.insert_size("6xl", FontSize::new(3.75, -100.));
+        self.insert_size("7xl", FontSize::new(4.5, -100.));
+        self.insert_size("8xl", FontSize::new(6.0, -100.));
+        self.insert_size("9xl", FontSize::new(8.0, -100.));
     }
     fn insert_builtin_family(&mut self) {
         self.insert_family("sans", r#"ui-sans-serif"#);

--- a/projects/tailwind-to-css/src/systems/font_system/font_size/mod.rs
+++ b/projects/tailwind-to-css/src/systems/font_system/font_size/mod.rs
@@ -10,7 +10,7 @@ impl FontSize {
     #[inline]
     pub fn new(size: f32, height: f32) -> Self {
         let size = LengthUnit::rem(size);
-        let height = if height < 0.0 { LengthUnit::rem(height) } else { LengthUnit::percent(height) };
+        let height = if height > 0.0 { LengthUnit::rem(height) } else { LengthUnit::percent(-height) };
         Self { size, height }
     }
     pub fn get_properties(&self) -> CssAttributes {


### PR DESCRIPTION
## Before

Note small percents and negative rem on line heights...

```css
text-md

:root {
    font-size: 1rem;
    line-height: 1.5%;
}

text-lg

:root {
    font-size: 1.125rem;
    line-height: 1.75%;
}

text-xl

:root {
    font-size: 1.25rem;
    line-height: 1.75%;
}

text-5xl

:root {
    font-size: 3rem;
    line-height: -1rem;
}

```

## After

```css
text-md

:root {
    font-size: 1rem;
    line-height: 1.5rem;
}

text-lg

:root {
    font-size: 1.125rem;
    line-height: 1.75rem;
}

text-xl

:root {
    font-size: 1.25rem;
    line-height: 1.75rem;
}

text-5xl

:root {
    font-size: 3rem;
    line-height: 100%;
}
```