### PR TITLE
🔧 Update `css-inline` to `0.8.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "fmt": "cargo fmt --all",
         "push": "wee test && git push",
         "reset": "git reset Head~ --soft",
-        "u": "cargo upgrade --workspace"
+        "u": "cargo upgrade --workspace",
+        "bump": "cargo release patch --workspace --no-publish --no-tags --execute"
     }
 }

--- a/projects/tailwind-from-css/Cargo.toml
+++ b/projects/tailwind-from-css/Cargo.toml
@@ -10,7 +10,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-css-inline = "0.8.2"
+css-inline = "0.8.4"
 
 [dev-dependencies]
 

--- a/projects/tailwind-from-html/Cargo.toml
+++ b/projects/tailwind-from-html/Cargo.toml
@@ -10,7 +10,7 @@ license = "MPL-2.0"
 edition = "2018"
 
 [dependencies]
-css-inline = "0.8.2"
+css-inline = "0.8.4"
 
 [dev-dependencies]
 


### PR DESCRIPTION
Hi! This PR updates `css-inline` to `0.8.4` as it contains a bugfix for some cases when selectors' specificity was ignored.