### PR TITLE
Fix small issues in py, my, and sizing

### DIFF
--- a/projects/tailwind-to-css/src/modules/sizing/builder.rs
+++ b/projects/tailwind-to-css/src/modules/sizing/builder.rs
@@ -2,7 +2,7 @@ use super::*;
 
 impl SizingUnit {
     pub fn parse(pattern: &[&str], arbitrary: &TailwindArbitrary) -> Result<Self> {
-        let px = |x| Ok(Self::Length(LengthUnit::em(x)));
+        let px = |x| Ok(Self::Length(LengthUnit::px(x)));
         match pattern {
             ["min"] => Ok(Self::Min),
             ["max"] => Ok(Self::Max),

--- a/projects/tailwind-to-css/src/modules/sizing/display.rs
+++ b/projects/tailwind-to-css/src/modules/sizing/display.rs
@@ -34,15 +34,28 @@ impl SizingUnit {
     }
 }
 
+impl TailwindSizingKind {
+    fn is_width(self) -> bool {
+        match self {
+            TailwindSizingKind::Width => true,
+            TailwindSizingKind::MinWidth => true,
+            TailwindSizingKind::MaxWidth => true,
+            TailwindSizingKind::Height => false,
+            TailwindSizingKind::MinHeight => false,
+            TailwindSizingKind::MaxHeight => false,
+        }
+    }
+}
+
 impl Display for TailwindSizingKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Width => f.write_str("w"),
-            Self::MinWidth => f.write_str("min-w"),
-            Self::MaxWidth => f.write_str("max-w"),
-            Self::Height => f.write_str("h"),
-            Self::MinHeight => f.write_str("min-h"),
-            Self::MaxHeight => f.write_str("max-h"),
+            Self::Width => f.write_str("width"),
+            Self::MinWidth => f.write_str("min-width"),
+            Self::MaxWidth => f.write_str("max-width"),
+            Self::Height => f.write_str("height"),
+            Self::MinHeight => f.write_str("min-height"),
+            Self::MaxHeight => f.write_str("max-height"),
         }
     }
 }
@@ -56,7 +69,7 @@ impl Display for TailwindSizing {
 impl TailwindInstance for TailwindSizing {
     fn attributes(&self, _: &TailwindBuilder) -> CssAttributes {
         let class = self.kind.to_string();
-        let width = self.size.get_attribute(true);
+        let width = self.size.get_attribute(self.kind.is_width());
         css_attributes! {
             class => width
         }

--- a/projects/tailwind-to-css/src/modules/spacing/margin/mod.rs
+++ b/projects/tailwind-to-css/src/modules/spacing/margin/mod.rs
@@ -36,7 +36,7 @@ impl TailwindMargin {
             ["mt", rest @ ..] => (SpacingAxis::new("mt", &["margin-top"]), rest),
             ["mb", rest @ ..] => (SpacingAxis::new("mb", &["margin-bottom"]), rest),
             ["mx", rest @ ..] => (SpacingAxis::new("mx", &["margin-left", "margin-right"]), rest),
-            ["my", rest @ ..] => (SpacingAxis::new("my", &["margin-top", "margin-right"]), rest),
+            ["my", rest @ ..] => (SpacingAxis::new("my", &["margin-top", "margin-bottom"]), rest),
             _ => return syntax_error!("Unknown margin axis"),
         };
         let size = SpacingSize::parse(rest, arbitrary, &Self::check_valid)?;

--- a/projects/tailwind-to-css/src/modules/spacing/padding/mod.rs
+++ b/projects/tailwind-to-css/src/modules/spacing/padding/mod.rs
@@ -36,7 +36,7 @@ impl TailwindPadding {
             ["pt", rest @ ..] => (SpacingAxis::new("pt", &["padding-top"]), rest),
             ["pb", rest @ ..] => (SpacingAxis::new("pb", &["padding-bottom"]), rest),
             ["px", rest @ ..] => (SpacingAxis::new("px", &["padding-left", "padding-right"]), rest),
-            ["py", rest @ ..] => (SpacingAxis::new("py", &["padding"]), rest),
+            ["py", rest @ ..] => (SpacingAxis::new("py", &["padding-top", "padding-bottom"]), rest),
             _ => return syntax_error!("Unknown padding axis"),
         };
         let size = SpacingSize::parse(rest, arbitrary, &Self::check_valid)?;

--- a/projects/tailwind-to-css/src/systems/instruction/resolver.rs
+++ b/projects/tailwind-to-css/src/systems/instruction/resolver.rs
@@ -76,9 +76,9 @@ impl TailwindInstruction {
             ["w", rest @ ..] => TailwindSizing::parse_width(rest, arbitrary)?.boxed(),
             ["min", "w", rest @ ..] => TailwindSizing::parse_width_min(rest, arbitrary)?.boxed(),
             ["max", "w", rest @ ..] => TailwindSizing::parse_width_max(rest, arbitrary)?.boxed(),
-            ["h", rest @ ..] => TailwindSizing::parse_width(rest, arbitrary)?.boxed(),
-            ["min", "h", rest @ ..] => TailwindSizing::parse_width_min(rest, arbitrary)?.boxed(),
-            ["max", "h", rest @ ..] => TailwindSizing::parse_width_max(rest, arbitrary)?.boxed(),
+            ["h", rest @ ..] => TailwindSizing::parse_height(rest, arbitrary)?.boxed(),
+            ["min", "h", rest @ ..] => TailwindSizing::parse_height_min(rest, arbitrary)?.boxed(),
+            ["max", "h", rest @ ..] => TailwindSizing::parse_height_max(rest, arbitrary)?.boxed(),
             // Typography System
             ["font", rest @ ..] => font_adaptor(rest, arbitrary)?,
             ["text", rest @ ..] => text_adaptor(rest, arbitrary)?,


### PR DESCRIPTION
Using this library I stumbled over some small errors in various places. This is by no means complete but maybe helpful nonetheless.  
- sizing: height classes were parsed as width classes, always used `vw` as unit, used `em` unit instead of `px` unit and generated wrong css class names
- py: padding on y axes was parsed as global padding
- my: margin on y axes was parsed as top and right margin