### PR TITLE
Fixes to compile

### DIFF
--- a/projects/tailwind-ast/src/ast/mod.rs
+++ b/projects/tailwind-ast/src/ast/mod.rs
@@ -35,7 +35,7 @@ pub fn parse_tailwind(input: &str) -> Result<Vec<AstStyle>, Err<Error<&str>>> {
 }
 
 /// `variant:ast-style(grouped)`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct AstGroup<'a> {
     /// Is a `!important` group
     pub important: bool,
@@ -55,7 +55,7 @@ pub enum AstGroupItem<'a> {
 }
 
 /// `not-variant:pseudo::-ast-element-[arbitrary]`
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct AstStyle<'a> {
     /// Is a `!important` style
     pub important: bool,

--- a/projects/tailwind-ast/src/ast/tests.rs
+++ b/projects/tailwind-ast/src/ast/tests.rs
@@ -43,25 +43,24 @@ fn test_variant() {
 fn test_style() {
     let input = AstStyle::parse("full").unwrap().1;
     let output = AstStyle {
-        //
         negative: false,
         variants: vec![],
         elements: vec!["full"],
         arbitrary: None,
+        ..Default::default()
     };
     assert_eq!(input, output);
     let input = AstStyle::parse("-top-1").unwrap().1;
     let output = AstStyle {
-        //
         negative: true,
         variants: vec![],
         elements: vec!["top", "1"],
         arbitrary: None,
+        ..Default::default()
     };
     assert_eq!(input, output);
     let input = AstStyle::parse("not-hover:sm:text-red-[200/50]").unwrap().1;
     let output = AstStyle {
-        //
         negative: false,
         variants: vec![
             ASTVariant { not: true, pseudo: false, names: vec!["hover"] },
@@ -69,6 +68,7 @@ fn test_style() {
         ],
         elements: vec!["text", "red"],
         arbitrary: Some("200/50"),
+        ..Default::default()
     };
     assert_eq!(input, output);
 }
@@ -83,21 +83,30 @@ fn test_style() {
 fn test_group() {
     let input = AstGroup::parse("w(full sm:auto)").unwrap().1;
     let output = AstGroup {
-        head: AstStyle { negative: false, variants: vec![], elements: vec!["w"], arbitrary: None },
+        head: AstStyle {
+            negative: false,
+            variants: vec![],
+            elements: vec!["w"],
+            arbitrary: None,
+            ..Default::default()
+        },
         children: vec![
             Styled(AstStyle {
                 negative: false,
                 variants: vec![],
                 elements: vec!["full"],
                 arbitrary: None,
+                ..Default::default()
             }),
             Styled(AstStyle {
                 negative: false,
                 variants: vec![ASTVariant { not: false, pseudo: false, names: vec!["sm"] }],
                 elements: vec!["auto"],
                 arbitrary: None,
+                ..Default::default()
             }),
         ],
+        ..Default::default()
     };
     assert_eq!(input, output);
     let input = AstGroup::parse("rotate(-3 hover:6 md:(3 hover:-6))").unwrap().1;
@@ -107,6 +116,7 @@ fn test_group() {
             variants: vec![],
             elements: vec!["rotate"],
             arbitrary: None,
+            ..Default::default()
         },
         children: vec![
             Styled(AstStyle {
@@ -114,12 +124,14 @@ fn test_group() {
                 variants: vec![],
                 elements: vec!["3"],
                 arbitrary: None,
+                ..Default::default()
             }),
             Styled(AstStyle {
                 negative: false,
                 variants: vec![ASTVariant { not: false, pseudo: false, names: vec!["hover"] }],
                 elements: vec!["6"],
                 arbitrary: None,
+                ..Default::default()
             }),
             Grouped(AstGroup {
                 head: AstStyle {
@@ -127,6 +139,7 @@ fn test_group() {
                     variants: vec![ASTVariant { not: false, pseudo: false, names: vec!["md"] }],
                     elements: vec![],
                     arbitrary: None,
+                    ..Default::default()
                 },
                 children: vec![
                     Styled(AstStyle {
@@ -134,6 +147,7 @@ fn test_group() {
                         variants: vec![],
                         elements: vec!["3"],
                         arbitrary: None,
+                        ..Default::default()
                     }),
                     Styled(AstStyle {
                         negative: true,
@@ -144,10 +158,13 @@ fn test_group() {
                         }],
                         elements: vec!["6"],
                         arbitrary: None,
+                        ..Default::default()
                     }),
                 ],
+                ..Default::default()
             }),
         ],
+        ..Default::default()
     };
     assert_eq!(input, output);
     let input = AstGroup::parse("bg-blue-500(hover:& focus:& active:&)").unwrap().1;
@@ -157,6 +174,7 @@ fn test_group() {
             variants: vec![],
             elements: vec!["bg", "blue", "500"],
             arbitrary: None,
+            ..Default::default()
         },
         children: vec![
             Styled(AstStyle {
@@ -164,20 +182,24 @@ fn test_group() {
                 variants: vec![ASTVariant { not: false, pseudo: false, names: vec!["hover"] }],
                 elements: vec!["&"],
                 arbitrary: None,
+                ..Default::default()
             }),
             Styled(AstStyle {
                 negative: false,
                 variants: vec![ASTVariant { not: false, pseudo: false, names: vec!["focus"] }],
                 elements: vec!["&"],
                 arbitrary: None,
+                ..Default::default()
             }),
             Styled(AstStyle {
                 negative: false,
                 variants: vec![ASTVariant { not: false, pseudo: false, names: vec!["active"] }],
                 elements: vec!["&"],
                 arbitrary: None,
+                ..Default::default()
             }),
         ],
+        ..Default::default()
     };
     assert_eq!(input, output);
 }

--- a/projects/tailwind-error/src/error_3rd/mod.rs
+++ b/projects/tailwind-error/src/error_3rd/mod.rs
@@ -10,8 +10,8 @@ mod for_glob;
 mod for_globset;
 #[cfg(feature = "html_parser")]
 mod for_html_parser;
-#[cfg(feature = "lsp-types")]
-mod for_lsp;
+// #[cfg(feature = "lsp-types")]
+// mod for_lsp;
 #[cfg(feature = "nom")]
 mod for_nom;
 #[cfg(feature = "num")]

--- a/projects/tailwind-rs/Readme.md
+++ b/projects/tailwind-rs/Readme.md
@@ -1,0 +1,22 @@
+# Tailwindcss in Rust
+
+Compile your HTML code into CSS using [Tailwindcss](https://tailwindcss.com/) in Rust.
+
+## Usage
+
+```rust
+use tailwind_rs::{CLIConfig, CssInlineMode, TailwindBuilder, Result};
+
+let mut config = CLIConfig::default();
+let mut builder = config.builder();
+config.minify = false;
+builder.preflight.disable = true;
+
+let input_html = "<div class=\"border-red-500 p-2\"></div>".to_string();
+
+config.mode = CssInlineMode::None;
+let (html, css) = config.compile_html(&input_html, &mut builder).unwrap();
+
+assert_eq!(html, input_html);
+assert_eq!(css, ".border-red-500 {\n  border-color: #ef4444;\n}\n\n.p-2 {\n  padding: .5rem;\n}\n");
+```

--- a/projects/tailwind-rs/src/lib.rs
+++ b/projects/tailwind-rs/src/lib.rs
@@ -4,6 +4,10 @@
 #![doc(html_logo_url = "https://upload.wikimedia.org/wikipedia/commons/d/d5/Tailwind_CSS_Logo.svg")]
 #![doc(html_favicon_url = "https://upload.wikimedia.org/wikipedia/commons/d/d5/Tailwind_CSS_Logo.svg")]
 
+// Test the README.md code snippets
+#[cfg(doctest)]
+pub struct ReadmeDoctests;
+
 pub use self::config::CLIConfig;
 pub use tailwind_error::{Result, TailwindError};
 
@@ -12,3 +16,25 @@ mod processor;
 mod support;
 
 pub use tailwind_css::{CssInlineMode, TailwindBuilder};
+
+#[cfg(test)]
+mod lib_tests {
+
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let mut config = CLIConfig::default();
+        let mut builder = config.builder();
+        config.minify = false;
+        builder.preflight.disable = true;
+
+        let input_html = "<div class=\"border-red-500 p-2\"></div>".to_string();
+
+        config.mode = CssInlineMode::None;
+        let (html, css) = config.compile_html(&input_html, &mut builder).unwrap();
+
+        assert_eq!(html, input_html);
+        assert_eq!(css, ".border-red-500 {\n  border-color: #ef4444;\n}\n\n.p-2 {\n  padding: .5rem;\n}\n");
+    }
+}

--- a/projects/tailwind-rs/src/support/support_html/mod.rs
+++ b/projects/tailwind-rs/src/support/support_html/mod.rs
@@ -8,6 +8,7 @@ impl CLIConfig {
     pub fn builder(&self) -> TailwindBuilder {
         TailwindBuilder::default()
     }
+    /// Compile html and css
     pub fn compile_html(&self, input: &str, tw: &mut TailwindBuilder) -> Result<(String, String)> {
         let html = match self.mode {
             CssInlineMode::None => HtmlConfig::trace_all_class(input, tw, self.obfuscate)?,

--- a/projects/tailwind-show/Cargo.toml
+++ b/projects/tailwind-show/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 tailwind-rs = { version = "0.2.*", path = "../tailwind-rs" }
-dioxus = { version = "0.4.0", features = [] }
+dioxus = { version = "0.2.4", features = ["web"] }
 wasm-logger = "0.2.0"
 log = "0.4.20"
 wasm-bindgen = "0.2.87"


### PR DESCRIPTION
Hello,

Tailwind in Rust seems like a good idea, and you've got a lot of great progress in these repos, thanks!

- When I went to use it, I found some compile errors and the docs were lacking, so I made a few fixes to correct this.

- `for_lsp` blocks compiling, so I disabled it.

- also there are 3 tests that's don't pass:

https://github.com/oovm/tailwind-rs/blob/a8df8947f81a4404f9a6fa3fe202633a84fa3c14/projects/tailwind-ast/src/ast/tests.rs#L21-L23

Are you still interested in keeping this repo going? If so, here's a pull request.
